### PR TITLE
fix: Renamed process to "dataframe.[read|write].csv" for consistency

### DIFF
--- a/src/rdmlibpy/dataframes/io.py
+++ b/src/rdmlibpy/dataframes/io.py
@@ -115,11 +115,11 @@ class DataFrameReadCSVBase(Loader):
 
 class DataFrameReadCSV(DataFrameReadCSVBase):
     version: str = '1'
-    name: str = 'dataframe.read_csv'
+    name: str = 'dataframe.read.csv'
 
 
 class DataFrameWriteCSV(Writer):
-    name: str = 'dataframe.write_csv'
+    name: str = 'dataframe.write.csv'
     version: str = '1'
 
     decimal: str = '.'

--- a/tests/dataframes/test_io.py
+++ b/tests/dataframes/test_io.py
@@ -15,7 +15,7 @@ class TestDataFrameReadCSV:
     def test_create_loader(self):
         loader = DataFrameReadCSV()
 
-        assert loader.name == 'dataframe.read_csv'
+        assert loader.name == 'dataframe.read.csv'
         assert loader.version == '1'
         assert loader.decimal == '.'
         assert loader.separator == ','
@@ -143,7 +143,7 @@ class TestDataFrameWriteCSV:
     def test_create_loader(self):
         writer = DataFrameWriteCSV()
 
-        assert writer.name == 'dataframe.write_csv'
+        assert writer.name == 'dataframe.write.csv'
         assert writer.version == '1'
         assert writer.decimal == '.'
         assert writer.separator == ','


### PR DESCRIPTION
BREAKING CHANGE: Workflows referencing the old names will break